### PR TITLE
Fixe source and blocked links

### DIFF
--- a/src/containers/home/components/11-zooming-in.tsx
+++ b/src/containers/home/components/11-zooming-in.tsx
@@ -41,7 +41,7 @@ const ZoomingIn = () => {
 
   return (
     <div ref={target} className="flex min-h-screen flex-col py-12 lg:py-16">
-      <div className="container">
+      <div className="container z-20">
         <div className="small-container">
           {/* DESKTOP */}
           <div className="pointer-events-none hidden sm:block">

--- a/src/containers/home/components/4-inequality.tsx
+++ b/src/containers/home/components/4-inequality.tsx
@@ -69,7 +69,7 @@ const Inequality = () => {
 
   return (
     <div ref={ref} className="h-[300vh] w-full">
-      <div className="container flex-1">
+      <div className="flex- container z-20">
         {contents.map(({ p1, p2, subtitle, title }, index) => {
           return (
             <div
@@ -113,8 +113,8 @@ const Inequality = () => {
         })}
       </div>
 
-      <div className="absolute h-[300vh] w-full sm:mt-[-50vh] sm:h-[350vh]">
-        <div className="pointer-events-none sticky top-0 h-[100vh] w-full sm:flex sm:pt-0">
+      <div className="pointer-events-none absolute h-[300vh] w-full sm:mt-[-50vh] sm:h-[350vh]">
+        <div className="sticky top-0 h-[100vh] w-full sm:flex sm:pt-0">
           <div className="flex-1"></div>
           <div className="flex flex-1 items-center justify-end">
             <RiveScrollAnimation
@@ -122,7 +122,7 @@ const Inequality = () => {
               fileName="diagram"
               stateMachine="Default"
               stateMachineInput="scrollPos"
-              className="pointer-events-none mt-[-5vh] h-[50vh] w-[100vw] sm:mt-0 sm:h-[45vw] sm:w-[45vw]"
+              className="mt-[-5vh] h-[50vh] w-[100vw] sm:mt-0 sm:h-[45vw] sm:w-[45vw]"
               autoplay
             />
           </div>

--- a/src/containers/home/components/5-distribution.tsx
+++ b/src/containers/home/components/5-distribution.tsx
@@ -72,13 +72,13 @@ const DistributionDefault = () => {
       </div>
       {/* DESKTOP */}
       <motion.div
-        className="absolute -z-10 mb-6 hidden h-[300vh] w-screen lg:flex"
+        className="absolute mb-6 hidden h-[300vh] w-screen lg:flex"
         style={{
           y: animationY,
           opacity: animationOpacity,
         }}
       >
-        <div className="sticky top-0 h-screen">
+        <div className="sticky top-0 z-20 h-screen">
           <div className="flex h-[calc(100vh-96px)] items-end">
             <RiveScrollAnimation
               scrollY={animationScrollProgress}
@@ -89,7 +89,7 @@ const DistributionDefault = () => {
               autoplay
             />
           </div>
-          <div className="container mt-6 w-full items-end justify-between text-sm text-middle-gray sm:flex">
+          <div className="container z-10 mt-6 w-full items-end justify-between text-sm text-middle-gray sm:flex">
             <p className="font-serif">
               Distribution of pre-tax national income by population group (2021).
             </p>
@@ -97,9 +97,11 @@ const DistributionDefault = () => {
               Source:{' '}
               <a
                 className="underline"
-                href="https://www.figma.com/file/tfBBt7rL4Rt0NJs7swlZdE/V2---Vizz-branding?node-id=347-55549&t=jWrtaEw0X7czunMf-4"
+                target="_blank"
+                rel="noreferrer"
+                href="https://oxfamilibrary.openrepository.com/bitstream/handle/10546/621341/bp-inequality-kills-170122-summ-en.pdf"
               >
-                World Inequality Database, World Bank
+                World Inequality Database, Oxfam
               </a>
             </p>
           </div>
@@ -107,8 +109,8 @@ const DistributionDefault = () => {
       </motion.div>
 
       {/* MOBILE */}
-      <div className="absolute flex h-[300vh] w-screen lg:hidden">
-        <div className="sticky top-0 h-screen">
+      <div className="AAAAAA absolute flex h-[300vh] w-screen lg:hidden">
+        <div className="sticky top-0 z-20 h-screen">
           <div className="flex h-full flex-col justify-end">
             <RiveScrollAnimation
               scrollY={animationScrollProgress}
@@ -126,9 +128,11 @@ const DistributionDefault = () => {
                 Source:{' '}
                 <a
                   className="underline"
-                  href="https://www.figma.com/file/tfBBt7rL4Rt0NJs7swlZdE/V2---Vizz-branding?node-id=347-55549&t=jWrtaEw0X7czunMf-4"
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://oxfamilibrary.openrepository.com/bitstream/handle/10546/621341/bp-inequality-kills-170122-summ-en.pdf"
                 >
-                  World Inequality Database, World Bank
+                  World Inequality Database, Oxfam
                 </a>
               </p>
             </div>

--- a/src/containers/home/components/5-distribution.tsx
+++ b/src/containers/home/components/5-distribution.tsx
@@ -15,6 +15,24 @@ const texts = [
   'The 10 richest men in the world own more than the bottom 3.1 billion people.',
 ];
 
+const Links = ({ className }: { className?: string }) => (
+  <p className={classNames(className)}>
+    Sources:{' '}
+    <a className="underline" target="_blank" rel="noreferrer" href="https://wid.world/data/">
+      World Inequality Database
+    </a>
+    ,{' '}
+    <a
+      className="underline"
+      target="_blank"
+      rel="noreferrer"
+      href="https://oxfamilibrary.openrepository.com/bitstream/handle/10546/621341/bp-inequality-kills-170122-summ-en.pdf"
+    >
+      Oxfam
+    </a>
+  </p>
+);
+
 const DistributionDefault = () => {
   const target = useRef(null);
   const { scrollYProgress: animationScrollProgress } = useScroll({
@@ -93,17 +111,7 @@ const DistributionDefault = () => {
             <p className="font-serif">
               Distribution of pre-tax national income by population group (2021).
             </p>
-            <p>
-              Source:{' '}
-              <a
-                className="underline"
-                target="_blank"
-                rel="noreferrer"
-                href="https://oxfamilibrary.openrepository.com/bitstream/handle/10546/621341/bp-inequality-kills-170122-summ-en.pdf"
-              >
-                World Inequality Database, Oxfam
-              </a>
-            </p>
+            <Links />
           </div>
         </div>
       </motion.div>
@@ -124,17 +132,8 @@ const DistributionDefault = () => {
               <p className="mb-2 font-serif">
                 Distribution of pre-tax national income by population group (2021).
               </p>
-              <p className="text-2xs">
-                Source:{' '}
-                <a
-                  className="underline"
-                  target="_blank"
-                  rel="noreferrer"
-                  href="https://oxfamilibrary.openrepository.com/bitstream/handle/10546/621341/bp-inequality-kills-170122-summ-en.pdf"
-                >
-                  World Inequality Database, Oxfam
-                </a>
-              </p>
+
+              <Links className="text-2xs" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes:

1.  the source link and name for the Distribution and global wealth chart
![Screenshot 2023-09-26 at 12 11 46](https://github.com/Vizzuality/climate-inequality/assets/48164343/a45b4c72-ee55-4739-a7d1-74fad22aac80)



2. links that were blocked and couldn’t be clicked 

- sections inequality (Kimberlé Williams Crenshaw)
- zooming in (World Inequality Database)

 
<img width="1336" alt="Screenshot 2023-09-26 at 12 07 31" src="https://github.com/Vizzuality/climate-inequality/assets/48164343/5e3571d9-be3c-4316-b308-5c3bfde04543">

![Screenshot 2023-09-26 at 12 08 48](https://github.com/Vizzuality/climate-inequality/assets/48164343/e744b3a3-5040-4815-b33e-0903a6b9c28f)

